### PR TITLE
Privacy Manifest

### DIFF
--- a/AFNetworking.xcodeproj/project.pbxproj
+++ b/AFNetworking.xcodeproj/project.pbxproj
@@ -194,6 +194,10 @@
 		5F4323DD1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */; };
 		5F4323DE1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */; };
 		5F4323DF1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer in Resources */ = {isa = PBXBuildFile; fileRef = 5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */; };
+		D6F68AB12B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D6F68AB02B85A18900E79941 /* PrivacyInfo.xcprivacy */; };
+		D6F68AB22B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D6F68AB02B85A18900E79941 /* PrivacyInfo.xcprivacy */; };
+		D6F68AB32B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D6F68AB02B85A18900E79941 /* PrivacyInfo.xcprivacy */; };
+		D6F68AB42B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D6F68AB02B85A18900E79941 /* PrivacyInfo.xcprivacy */; };
 		E2B10D8E233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer in Resources */ = {isa = PBXBuildFile; fileRef = E2B10D8B233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer */; };
 		E2B10D8F233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer in Resources */ = {isa = PBXBuildFile; fileRef = E2B10D8B233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer */; };
 		E2B10D90233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer in Resources */ = {isa = PBXBuildFile; fileRef = E2B10D8B233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer */; };
@@ -322,6 +326,7 @@
 		5F4323D41BF63CB0003B8749 /* GoogleComServerTrustChainPath1 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = GoogleComServerTrustChainPath1; sourceTree = "<group>"; };
 		5F4323D81BF63CBA003B8749 /* GoogleComServerTrustChainPath2 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = GoogleComServerTrustChainPath2; sourceTree = "<group>"; };
 		5F4323DC1BF63CCC003B8749 /* GeoTrust_Global_CA_Root.cer */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = GeoTrust_Global_CA_Root.cer; sourceTree = "<group>"; };
+		D6F68AB02B85A18900E79941 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		E2B10D8B233035100004E005 /* Starfield Services Root Certificate Authority - G2.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Starfield Services Root Certificate Authority - G2.cer"; sourceTree = "<group>"; };
 		E2B10D8C233035100004E005 /* Amazon Root CA 1.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Amazon Root CA 1.cer"; sourceTree = "<group>"; };
 		E2B10D8D233035100004E005 /* Amazon.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = Amazon.cer; sourceTree = "<group>"; };
@@ -526,6 +531,7 @@
 				439E280C247E16DE004467ED /* LICENSE */,
 				439E2813247E16DE004467ED /* Package.swift */,
 				439E2810247E16DE004467ED /* README.md */,
+				D6F68AB02B85A18900E79941 /* PrivacyInfo.xcprivacy */,
 			);
 			name = "Supporting Files";
 			path = AFNetworking;
@@ -865,6 +871,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F68AB42B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -953,6 +960,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F68AB12B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -960,6 +968,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F68AB22B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -967,6 +976,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F68AB32B85A18900E79941 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AFNetworking/PrivacyInfo.xcprivacy
+++ b/AFNetworking/PrivacyInfo.xcprivacy
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   PrivacyInfo.xcprivacy
-   AFNetworking
-
-   Created by Sato, Yukihiro | Yukki | ECID on 2024/02/21.
-   Copyright (c) 2024 AFNetworking. All rights reserved.
--->
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/AFNetworking/PrivacyInfo.xcprivacy
+++ b/AFNetworking/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   PrivacyInfo.xcprivacy
+   AFNetworking
+
+   Created by Sato, Yukihiro | Yukki | ECID on 2024/02/21.
+   Copyright (c) 2024 AFNetworking. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/AFNetworking/PrivacyInfo.xcprivacy
+++ b/AFNetworking/PrivacyInfo.xcprivacy
@@ -9,15 +9,6 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>CA92.1</string>
-			</array>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/findRequiredReasonAPIUsage.sh
+++ b/findRequiredReasonAPIUsage.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Created with reference below
+# https://gist.github.com/MarcoEidinger/22feb1588c3d7be41c42853a77e52772
+
+# https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+searchTerms=(
+    # Swift
+    ## File timestamp APIs
+    "creationDate"
+    "modificationDate"
+    "fileModificationDate"
+    "contentModificationDateKey"
+    "creationDateKey"
+    "getattrlist"
+    "getattrlistbulk"
+    "fgetattrlist"
+    "stat"
+    "fstat"
+    "fstatat"
+    "lstat"
+    "getattrlistat"
+    ## System boot time APIs
+    "systemUptime"
+    "mach_absolute_time"
+    ## Disk space APIs
+    "volumeAvailableCapacityKey"
+    "volumeAvailableCapacityForImportantUsageKey"
+    "volumeAvailableCapacityForOpportunisticUsageKey"
+    "volumeTotalCapacityKey"
+    "systemFreeSize"
+    "systemSize"
+    "statfs"
+    "statvfs"
+    "fstatfs"
+    "fstatvfs"
+    "getattrlist"
+    "fgetattrlist"
+    "getattrlistat"
+    ## Active keyboard APIs
+    "activeInputModes"
+    ## User defaults APIs
+    "UserDefaults"
+    # Objc
+    ## File timestamp APIs
+    NSFileCreationDate
+    NSFileModificationDate
+    fileModificationDate
+    NSURLContentModificationDateKey
+    NSURLCreationDateKey
+    getattrlist
+    getattrlistbulk
+    fgetattrlist
+    stat
+    fstat
+    fstatat
+    lstat
+    getattrlistat
+    ## System boot time APIs
+    systemUptime
+    mach_absolute_time
+    ## Disk space APIs
+    NSURLVolumeAvailableCapacityKey
+    NSURLVolumeAvailableCapacityForImportantUsageKey
+    NSURLVolumeAvailableCapacityForOpportunisticUsageKey
+    NSURLVolumeTotalCapacityKey
+    NSFileSystemFreeSize
+    NSFileSystemSize
+    statfs
+    statvfs
+    fstatfs
+    fstatvfs
+    getattrlist
+    fgetattrlist
+    getattrlistat
+    ## Active keyboard APIs
+    activeInputModes
+    ## User defaults APIs
+    NSUserDefaults
+)
+search_dir="$1"
+
+if [ -z "$search_dir" ]; then
+    echo "Usage: $0 <search_dir>"
+    exit 1
+fi
+
+for pattern in "${searchTerms[@]}"; do
+    results=`find "$search_dir" -type f \( -name "*.swift" -o -name "*.m" \) -exec grep -Hn -Fw "$pattern" {} + | awk -F ':' -v OFS='\t' '{ print $1,$2,$3 }'`
+    while read line
+    do
+    echo "${pattern}\t${line}"
+    done <<< "${results}"
+done


### PR DESCRIPTION
## 修正内容

Privacy Manifest対応として `PrivacyInfo.xcprivacy` を追加。

Appleが公開している[PrivacyManifest対応を要するSDKのリスト](https://developer.apple.com/jp/support/third-party-SDK-requirements/)にAFNetworkingは記載されているが、[Required reason APIのリスト](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc)に記載されているAPIはコンパイルされるコード上には存在しない。

### API探索スクリプト（findRequiredReasonAPIUsage.sh）実行結果

```
JP-NVFP09JFQQ:AFNetworking yukihiro.sato$ sh findRequiredReasonAPIUsage.sh .
creationDate
modificationDate
fileModificationDate
contentModificationDateKey
creationDateKey
getattrlist
getattrlistbulk
fgetattrlist
stat
fstat
fstatat
lstat
getattrlistat
systemUptime
mach_absolute_time
volumeAvailableCapacityKey
volumeAvailableCapacityForImportantUsageKey
volumeAvailableCapacityForOpportunisticUsageKey
volumeTotalCapacityKey
systemFreeSize
systemSize
statfs
statvfs
fstatfs
fstatvfs
getattrlist
fgetattrlist
getattrlistat
activeInputModes
UserDefaults
NSFileCreationDate
NSFileModificationDate
fileModificationDate
NSURLContentModificationDateKey
NSURLCreationDateKey
getattrlist
getattrlistbulk
fgetattrlist
stat
fstat
fstatat
lstat
getattrlistat
systemUptime
mach_absolute_time
NSURLVolumeAvailableCapacityKey
NSURLVolumeAvailableCapacityForImportantUsageKey
NSURLVolumeAvailableCapacityForOpportunisticUsageKey
NSURLVolumeTotalCapacityKey
NSFileSystemFreeSize
NSFileSystemSize
statfs
statvfs
fstatfs
fstatvfs
getattrlist
fgetattrlist
getattrlistat
activeInputModes
NSUserDefaults	./Example/Today Extension Example/TodayViewController.m	87	        [[NSUserDefaults standardUserDefaults] removeObjectForKey
NSUserDefaults	./Example/Today Extension Example/TodayViewController.m	88	        [[NSUserDefaults standardUserDefaults] synchronize];
NSUserDefaults	./Example/Today Extension Example/TodayViewController.m	93	    [[NSUserDefaults standardUserDefaults] setObject
NSUserDefaults	./Example/Today Extension Example/TodayViewController.m	94	    [[NSUserDefaults standardUserDefaults] synchronize];
NSUserDefaults	./Example/Today Extension Example/TodayViewController.m	98	    NSData *postData = [[NSUserDefaults standardUserDefaults] objectForKey
JP-NVFP09JFQQ:AFNetworking yukihiro.sato$
```


[Exampleコード](https://github.com/Fablic/AFNetworking/blob/master/Example/Today%20Extension%20Example/TodayViewController.m#L87-L94)の中に合致するもの（[UserDefaults](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc#:~:text=NSUserDefaults)）があるが、コンパイルされないはずなので追記はしない。

ということなのでほぼファイルを追加したのみになっている（何のために必要なのか...）。

## 動作確認

- [x] ビルドできること
